### PR TITLE
Fabric 1.16.5 release

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     ]
   },
   "depends": {
-    "fabricloader": ">=0.16.10",
+    "fabricloader": ">=0.4.0",
     "minecraft": "~1.16.5",
     "java": ">=8",
     "fabric": "*"


### PR DESCRIPTION
A release will be made from this PR, multiple versions of fabric in the same jar would be good, but as of the next version (1.17.1), code has already been changed in the APIs, mainly in Minecraft, reflection does not apply because of mapping problems.