### PR TITLE
Rename `Manual` loader to `ReadFolder`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ loader:
 **Available types:**
 
 <details>
-  <summary><strong>Manual</strong> <i>simple loading from folder</i></summary>
+  <summary><strong>ReadFolder</strong> <i>simple loading from folder</i></summary>
   Uses an existing folder of any provided path.
 
 ```yaml
-  type: Manual
+  type: ReadFolder
 
   # Relative to the server root folder.
   # Is inside `Cool Folder` (for this example) the resource pack files should be.
@@ -134,9 +134,9 @@ loader:
   # To ignore a file a file:
   # toDelete: "assets/minecraft/i_will_be_deleted.txt"
 
-  # This can be any loader, For this loader example we are using simple Manual loader.
+  # This can be any loader, For this loader example we are using simple ReadFolder loader.
   loader:
-    type: Manual
+    type: ReadFolder
     folder: "rnu resource pack/Cool Folder/"
   ```
 
@@ -162,9 +162,9 @@ loader:
   # For overriding cases, loaders on the top of the list have major priority, this is,
   # their files will replace the other files.
   loaders:
-    - type: Manual
+    - type: ReadFolder
       folder: "rnu resource pack/Cool Folder/"
-    - type: Manual
+    - type: ReadFolder
       folder: "plugins/ModelEngine/resource pack/"
   ```
 

--- a/bukkit/src/main/resources/config.yml
+++ b/bukkit/src/main/resources/config.yml
@@ -28,5 +28,5 @@ resendingDelay: 40
 loader:
   # In this example we are using a simple loader file, check all the loaders types here:
   # https://github.com/Robsutar/resource-pack-no-upload/?tab=readme-ov-file#creating-resource-pack-loader
-  type: Manual
+  type: ReadFolder
   folder: "rnu resource pack/Cool Folder/"

--- a/core/src/main/java/com/robsutar/rnu/ResourcePackLoader.java
+++ b/core/src/main/java/com/robsutar/rnu/ResourcePackLoader.java
@@ -49,8 +49,8 @@ public interface ResourcePackLoader {
         if (raw.get("type") == null) throw new IllegalArgumentException("Missing loader type");
         String type = OC.str(raw.get("type"));
         switch (type) {
-            case "Manual":
-                return new Manual(raw);
+            case "ReadFolder":
+                return new ReadFolder(raw);
             case "Merged":
                 return new Merged(tempFolder, raw);
             case "Download":
@@ -65,10 +65,10 @@ public interface ResourcePackLoader {
         }
     }
 
-    class Manual implements ResourcePackLoader {
+    class ReadFolder implements ResourcePackLoader {
         private final File folder;
 
-        public Manual(Map<String, Object> raw) {
+        public ReadFolder(Map<String, Object> raw) {
             this.folder = new File(OC.str(raw.get("folder")));
         }
 

--- a/fabric/src/main/resources/config.yml
+++ b/fabric/src/main/resources/config.yml
@@ -28,5 +28,5 @@ resendingDelay: 40
 loader:
   # In this example we are using a simple loader file, check all the loaders types here:
   # https://github.com/Robsutar/resource-pack-no-upload/?tab=readme-ov-file#creating-resource-pack-loader
-  type: Manual
+  type: ReadFolder
   folder: "rnu resource pack/Cool Folder/"

--- a/velocity/src/main/resources/config.yml
+++ b/velocity/src/main/resources/config.yml
@@ -28,5 +28,5 @@ resendingDelay: 40
 loader:
   # In this example we are using a simple loader file, check all the loaders types here:
   # https://github.com/Robsutar/resource-pack-no-upload/?tab=readme-ov-file#creating-resource-pack-loader
-  type: Manual
+  type: ReadFolder
   folder: "rnu resource pack/Cool Folder/"


### PR DESCRIPTION
More clear and direct name.

Closes #67.